### PR TITLE
win10 QEMULauncher.ini and ultibo.img

### DIFF
--- a/QEMULauncher.ini
+++ b/QEMULauncher.ini
@@ -1,0 +1,2 @@
+[QEMULauncher]
+ExtraParams=-drive file=ultibo.img,if=sd,format=raw

--- a/fipq.lpi
+++ b/fipq.lpi
@@ -31,7 +31,7 @@
         <FormatVersion Value="1"/>
       </local>
     </RunParams>
-    <Units Count="4">
+    <Units Count="5">
       <Unit0>
         <Filename Value="fipq.lpr"/>
         <IsPartOfProject Value="True"/>
@@ -48,6 +48,10 @@
         <Filename Value="ForthIntel/secondary.pas"/>
         <IsPartOfProject Value="True"/>
       </Unit3>
+      <Unit4>
+        <Filename Value="QEMULauncher.ini"/>
+        <IsPartOfProject Value="True"/>
+      </Unit4>
     </Units>
   </ProjectOptions>
   <CompilerOptions>


### PR DESCRIPTION
This captures ultibo.img which should be replaced with a script for creating it, once that script is determined for win10. Mark.