### PR TITLE
UltiboApi.pas

### DIFF
--- a/ForthIntel/secondary.pas
+++ b/ForthIntel/secondary.pas
@@ -23,6 +23,8 @@ var
 
 
 implementation
+uses
+ ultiboapi;
 
 {$push}
 {$hints off}   // hide warning var not initialized
@@ -683,6 +685,7 @@ begin
           EvalString(': !0exit ` 0branch 2 cells , ` exit ; immediate');
           EvalString(': 0exit  ` not ` 0branch 2 cells , ` exit ; immediate');
 
+          UltiboApiAddPrimitives;
 
 
 

--- a/ForthIntel/ultiboapi.pas
+++ b/ForthIntel/ultiboapi.pas
@@ -1,0 +1,51 @@
+unit UltiboApi;
+
+interface
+procedure UltiboApiAddPrimitives;
+
+implementation
+uses
+ parser,
+ globaltypes,globalconst,globalconfig,console,logging,serial;
+
+function IntToBool(X:Integer):Boolean;
+begin
+ Result:=X <> 0;
+end;
+
+procedure P_Ultibo_Uses_UltiboApi_StartSerialLogging;
+begin
+ LOGGING_INCLUDE_COUNTER:=False;
+ LOGGING_INCLUDE_TICKCOUNT:=True;
+ SERIAL_REGISTER_LOGGING:=True;
+ SerialLoggingDeviceAdd(SerialDeviceGetDefault);
+ SERIAL_REGISTER_LOGGING:=False;
+ LoggingDeviceSetDefault(LoggingDeviceFindByType(LOGGING_TYPE_SERIAL));
+end;
+
+procedure P_Ultibo_Uses_Console_ConsoleWindowGetDefault;
+begin
+ Push(Integer(ConsoleWindowGetDefault(ConsoleDeviceGetDefault)));
+end;
+
+procedure P_Ultibo_Uses_Console_ConsoleWindowClearEx;
+var
+ Handle,X1,X2,Y1,Y2,Cursor:Integer;
+begin
+ Handle:=Pop;
+ X1:=Pop;
+ X2:=Pop;
+ X1:=Pop;
+ X2:=Pop;
+ Cursor:=Pop;
+ Push(ConsoleWindowClearEx(Handle,X1,Y1,X2,Y2,IntToBool(Cursor)));
+end;
+
+procedure UltiboApiAddPrimitives;
+begin
+ AddPrim(0, 'Ultibo.Uses.UltiboApi.StartSerialLogging', @P_Ultibo_Uses_UltiboApi_StartSerialLogging);
+ AddPrim(0, 'Ultibo.Uses.Console.ConsoleWindowGetDefault', @P_Ultibo_Uses_Console_ConsoleWindowGetDefault);
+ AddPrim(0, 'Ultibo.Uses.Console.ConsoleWindowClearEx', @P_Ultibo_Uses_Console_ConsoleWindowClearEx);
+end;
+
+end.

--- a/fipq/qlaunch
+++ b/fipq/qlaunch
@@ -4,6 +4,6 @@ source fipq.env
 
 DRIVE="-drive file=$IMG,if=sd,format=raw"
 KERNEL="-kernel ../kernel.bin"
-# KERNEL="-kernel ../fipq-kernel-qemuvpb.img"
-qemu-system-arm -machine versatilepb -cpu cortex-a8 -m 256M $DRIVE $KERNEL
+KERNEL="-kernel ../fipq-kernel-qemuvpb.img"
+qemu-system-arm -machine versatilepb -cpu cortex-a8 -m 256M $DRIVE $KERNEL -serial stdio
 


### PR DESCRIPTION
I recommend a rebase merge to squash my wip commits.

This adds a serial port to the qemu machine, attached to stdio which is inherited from the bash shell that launched qemu. It adds some ultibo forth words especially Ultibo.Uses.UltiboApi.StartSerialLogging which starts utlibo's logging, directed to the first serial port and thus to the shell that started qemu.

Tested using buildall and qlaunch on bash/git/win10 (needed to add /c/Utlibo/Core/QEMU to path and also copy ultimc-kernel-qemuvpb.img to kernel.bin.)

Please review and refactor in the direction that you want to go. Once you approve this approach, I'll start to add more ultibo forth words. Some scripting/tooling ought to be able to import a lot of ultibo's procedures.

Mark