### PR TITLE
qemu-telnet will build qemu version, launch and connect with telnet

### DIFF
--- a/ShellForth.pas
+++ b/ShellForth.pas
@@ -1,0 +1,212 @@
+{
+Ultibo Forth Shell extension unit.
+
+Copyright (C) 2015 - SoftOz Pty Ltd.
+
+Arch
+====
+
+ <All>
+
+Boards
+======
+
+ <All>
+
+Licence
+=======
+
+ LGPLv2.1 with static linking exception (See COPYING.modifiedLGPL.txt)
+ 
+Credits
+=======
+
+ Information for this unit was obtained from:
+
+ 
+References
+==========
+
+ 
+
+Shell Forth
+===========
+
+}
+
+{$mode delphi} {Default to Delphi compatible syntax}
+{$H+}          {Default to AnsiString}
+{$inline on}   {Allow use of Inline procedures}
+
+unit ShellForth;
+
+interface
+
+uses GlobalConfig,GlobalConst,GlobalTypes,Platform,Threads,Devices,FileSystem,SysUtils,Classes,Ultibo,UltiboClasses,UltiboUtils,Shell,HTTP;
+
+//To Do //Look for:
+
+//--
+
+{==============================================================================}
+{Global definitions}
+//{$INCLUDE ..\core\GlobalDefines.inc}
+
+{==============================================================================}
+type
+ {Shell Forth specific clases}
+ TShellForth = class(TShellCommand)
+ public
+  {}
+  constructor Create;
+ private
+  {Internal Variables}
+ 
+  {Internal Methods}
+  
+ protected
+  {Internal Variables}
+
+  {Internal Methods}
+  
+ public
+  {Public Properties}
+
+  {Public Methods}
+  function DoHelp(AShell:TShell;ASession:TShellSession):Boolean; override;
+  function DoInfo(AShell:TShell;ASession:TShellSession):Boolean; override;
+  function DoCommand(AShell:TShell;ASession:TShellSession;AParameters:TStrings):Boolean; override;
+ end;
+ 
+ //TShellWGET = class(TShellCommand) //To Do //Simple WGET 
+
+{==============================================================================}
+{Initialization Functions}
+procedure ShellForthInit;
+
+{==============================================================================}
+{Shell Forth Functions}
+ 
+{==============================================================================}
+{Shell Forth Helper Functions}
+ 
+{==============================================================================}
+{==============================================================================}
+
+implementation
+
+{==============================================================================}
+{==============================================================================}
+var
+ {Shell Forth specific variables}
+ ForthInterpreter:Integer; // Probably replace with an object refernce
+ ShellForthInitialized:Boolean;
+ 
+{==============================================================================}
+{==============================================================================}
+{TShellForth}
+constructor TShellForth.Create;
+begin
+ inherited Create;
+ Name:='Forth';
+ Flags:=SHELL_COMMAND_FLAG_INFO or SHELL_COMMAND_FLAG_HELP;
+end;
+
+function TShellForth.DoHelp(AShell:TShell;ASession:TShellSession):Boolean; 
+begin
+ {}
+ Result:=False;
+ 
+ {Check Shell}
+ if AShell = nil then Exit;
+ 
+ {Do Help}
+ AShell.DoOutput(ASession,'Submit sentence to forth interpreter');
+ AShell.DoOutput(ASession,'');
+ 
+ {Return Result}
+ Result:=True;
+end;
+ 
+function TShellForth.DoInfo(AShell:TShell;ASession:TShellSession):Boolean; 
+begin
+ {}
+ Result:=False;
+ 
+ {Check Shell}
+ if AShell = nil then Exit;
+ 
+ {Do Info}
+ Result:=AShell.DoOutput(ASession,'Submit sentence to forth interpreter');
+end;
+
+
+function TShellForth.DoCommand(AShell:TShell;ASession:TShellSession;AParameters:TStrings):Boolean; 
+var
+ Sentence:String;
+ i:Integer;
+begin
+ {}
+ Result:=False;
+ 
+ {Check Shell}
+ if AShell = nil then Exit;
+
+ {Check Parameters}
+ if AParameters = nil then Exit;
+
+ if ForthInterpreter = 0 then
+  begin
+   ForthInterpreter:=1; 
+   AShell.DoOutput(ASession, Format('forth interpreter initialized',[]));
+  end;
+
+ Sentence:='';
+ for I:=0 to AParameters.Count - 1 do
+  begin
+   if Length(Sentence) <> 0 then
+    Sentence:=Sentence + ' ';
+   Sentence:=Sentence + AParameters[I];
+  end;
+ AShell.DoOutput(ASession, Format('forth sentence <%s>',[Sentence]));
+ AShell.DoOutput(ASession, Format('forth output is %s',['...']));
+end;
+ 
+{==============================================================================}
+{==============================================================================}
+{Initialization Functions}
+procedure ShellForthInit;
+begin
+ {}
+ {Check Initialized}
+ if ShellForthInitialized then Exit;
+ 
+ {Register FileSystem Commands}
+ ShellRegisterCommand(TShellForth.Create);
+
+ ShellForthInitialized:=True;
+end;
+ 
+{==============================================================================}
+{==============================================================================}
+{Shell Forth Functions}
+ 
+{==============================================================================}
+{==============================================================================}
+{Shell Forth Helper Functions}
+ 
+{==============================================================================}
+{==============================================================================}
+
+initialization
+ ShellForthInit;
+
+{==============================================================================}
+ 
+finalization
+ {Nothing}
+
+{==============================================================================}
+{==============================================================================}
+ 
+end.

--- a/armall.pas
+++ b/armall.pas
@@ -19,8 +19,9 @@ uses
   , SysUtils
   , Classes
   , Ultibo
-  , DWCOTG,FileSystem,MMC,FATFS,Keyboard
-
+  , DWCOTG, Keyboard
+  , FileSystem, MMC, FATFS
+  , RemoteShell, ShellForth
   , secondary
   , parser
 

--- a/qemu-telnet
+++ b/qemu-telnet
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -e
+
+trap finish EXIT
+function finish {
+  PGID=$(ps -o pgid= $$ | grep -o [0-9]*)
+  setsid kill -- -$PGID
+  exit 0
+}
+
+LPIFILE=$1
+if [[ $LPIFILE == "" ]]
+then
+    LPIFILE=fipq.lpi
+fi
+
+function buildmode {
+    MODE=$1
+    echo
+    echo building $LPIFILE $MODE ...
+    rm -rf lib/
+    WD=$(pwd)
+    if [ -d "/c/Ultibo/Core" ]; then
+	LAZDIR=/c/Ultibo/Core
+    fi
+    if [ -d "$HOME/ultibo/core" ]; then
+	LAZDIR="$HOME/ultibo/core"
+    fi
+    pushd $LAZDIR >& /dev/null
+    rm -f kernel*.img kernel.bin
+    ./lazbuild --build-mode=BUILD_MODE_$MODE $WD/$LPIFILE > errors.txt 2>&1
+    popd >& /dev/null
+    mv kernel* $(basename $LPIFILE)-kernel-${MODE,,}.img
+}
+
+buildmode QEMUVPB
+
+DRIVE="-drive file=fipq/ultibo.img,if=sd,format=raw"
+KERNEL="-kernel $(basename $LPIFILE)-kernel-qemuvpb.img"
+DISPLAY="-display none"
+NET="-net nic -net user,hostfwd=tcp::5823-:23"
+CMDLINE="NETWORK0_IP_CONFIG=STATIC NETWORK0_IP_ADDRESS=10.0.2.15 NETWORK0_IP_NETMASK=255.255.255.0 NETWORK0_IP_GATEWAY=10.0.2.2"
+echo
+echo starting qemu and telnet ... wait for ultibo prompt ... then escape with ! and enter \"mode line\"
+qemu-system-arm -machine versatilepb -cpu cortex-a8 -m 256M $DRIVE $KERNEL $NET $DISPLAY -append "$CMDLINE" |& egrep -v '^(ALSA |alsa:|audio:|pulseaudio:)' &
+echo
+sleep 1
+telnet -e ! localhost 5823


### PR DESCRIPTION
qemu-telnet will build qemu version, launch it, and conect with telnet.

telnet connects to RemoteShell.pas which is extended by ShellForth.pas.

ShellForth provides the forth command which is intended to provide access to a forth interpreter.

Type "forth 1 2 3" to push 1 2 3 on the stack. (It won't work yet, but that's how to do it.)

Type "help forth" or "info forth"

RemoteShell provides line editing but I've found that I need to tell telnet "mode line" to get the right echo experience. Escape character is "!" to enter telnet commands. This inconvenience should be eliminated eventually.

The design is that the forth command provides one line to the interpreter. An improved design would enter a forth repl so that "forth" wouldn't need to be typed for each command.

Can you add the interpreter call to ShellForth?

Putting a forth repl on a serial line is not hard but I don't think the line editing is readily available for a serial line.

Tested on debian/x64.

Regards, Mark